### PR TITLE
Task 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ## S3 bucket URL
 
-- http://aws-for-js-practitioner.s3-website-us-east-1.amazonaws.com/
+- http://aws-for-js-practitioner.s3-website-eu-west-1.amazonaws.com/
 
 ## CloudFront
 
-- https://d2mea1v4ijfmoe.cloudfront.net/
+- https://d1t533ukpfai4z.cloudfront.net

--- a/serverless.yml
+++ b/serverless.yml
@@ -3,6 +3,7 @@ service: store
 provider:
   name: aws
   runtime: nodejs16.x
+  region: eu-west-1
 
 plugins:
   - serverless-finch
@@ -60,7 +61,7 @@ resources:
       Properties:
         DistributionConfig:
           Origins:
-            - DomainName: ${self:custom.s3BucketName}.s3.amazonaws.com
+            - DomainName: ${self:custom.s3BucketName}.s3.eu-west-1.amazonaws.com
               ## An identifier for the origin which must be unique within the distribution
               Id: myS3Origin
               ## In case you don't want to restrict the bucket access use CustomOriginConfig and remove S3OriginConfig

--- a/src/app/admin/manage-products/manage-products.service.ts
+++ b/src/app/admin/manage-products/manage-products.service.ts
@@ -33,9 +33,7 @@ export class ManageProductsService extends ApiService {
     const url = this.getUrl('import', 'import');
 
     return this.http.get<string>(url, {
-      params: {
-        name: fileName,
-      },
+      params: { fileName },
     });
   }
 }

--- a/src/app/admin/manage-products/manage-products.service.ts
+++ b/src/app/admin/manage-products/manage-products.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Injector } from '@angular/core';
 import { EMPTY, Observable } from 'rxjs';
 import { ApiService } from '../../core/api.service';
 import { switchMap } from 'rxjs/operators';
+import { HttpHeaders } from '@angular/common/http';
 
 @Injectable()
 export class ManageProductsService extends ApiService {
@@ -31,9 +32,16 @@ export class ManageProductsService extends ApiService {
 
   private getPreSignedUrl(fileName: string): Observable<string> {
     const url = this.getUrl('import', 'import');
+    const authorizationToken = localStorage.getItem('authorization_token');
+    let headers = new HttpHeaders();
+
+    if (authorizationToken) {
+      headers = headers.append('Authorization', `Basic ${authorizationToken}`);
+    }
 
     return this.http.get<string>(url, {
       params: { fileName },
+      headers,
     });
   }
 }

--- a/src/app/products/products.service.ts
+++ b/src/app/products/products.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 
-import { EMPTY, Observable, of, throwError } from 'rxjs';
+import { EMPTY, Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 import { Product } from './product.interface';
@@ -64,7 +64,9 @@ export class ProductsService extends ApiService {
     }
 
     const url = this.getUrl('bff', 'products');
-    return this.http.get<Product[]>(url);
+    return this.http
+      .get<{ products: Product[] }>(url)
+      .pipe(map((res) => res.products));
   }
 
   getProductsForCheckout(ids: string[]): Observable<Product[]> {

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -5,15 +5,15 @@ export const environment: Config = {
   apiEndpoints: {
     product: 'https://.execute-api.eu-west-1.amazonaws.com/dev',
     order: 'https://.execute-api.eu-west-1.amazonaws.com/dev',
-    import: 'https://.execute-api.eu-west-1.amazonaws.com/dev',
-    bff: 'https://.execute-api.eu-west-1.amazonaws.com/dev',
+    import: 'https://3fxyfzhaij.execute-api.eu-west-1.amazonaws.com/dev',
+    bff: 'https://abzfadapjd.execute-api.eu-west-1.amazonaws.com/dev',
     cart: 'https://.execute-api.eu-west-1.amazonaws.com/dev',
   },
   apiEndpointsEnabled: {
     product: false,
     order: false,
-    import: false,
-    bff: false,
+    import: true,
+    bff: true,
     cart: false,
   },
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -10,14 +10,14 @@ export const environment: Config = {
     product: 'https://.execute-api.eu-west-1.amazonaws.com/dev',
     order: 'https://.execute-api.eu-west-1.amazonaws.com/dev',
     import: 'https://.execute-api.eu-west-1.amazonaws.com/dev',
-    bff: 'https://.execute-api.eu-west-1.amazonaws.com/dev',
+    bff: 'https://abzfadapjd.execute-api.eu-west-1.amazonaws.com/dev',
     cart: 'https://.execute-api.eu-west-1.amazonaws.com/dev',
   },
   apiEndpointsEnabled: {
     product: false,
     order: false,
     import: false,
-    bff: false,
+    bff: true,
     cart: false,
   },
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -9,14 +9,14 @@ export const environment: Config = {
   apiEndpoints: {
     product: 'https://.execute-api.eu-west-1.amazonaws.com/dev',
     order: 'https://.execute-api.eu-west-1.amazonaws.com/dev',
-    import: 'https://.execute-api.eu-west-1.amazonaws.com/dev',
+    import: 'https://3fxyfzhaij.execute-api.eu-west-1.amazonaws.com/dev',
     bff: 'https://abzfadapjd.execute-api.eu-west-1.amazonaws.com/dev',
     cart: 'https://.execute-api.eu-west-1.amazonaws.com/dev',
   },
   apiEndpointsEnabled: {
     product: false,
     order: false,
-    import: false,
+    import: true,
     bff: true,
     cart: false,
   },


### PR DESCRIPTION
Link to BE pr: https://github.com/alinakogut/aws-for-js-service/pull/5
Import API: https://abzfadapjd.execute-api.eu-west-1.amazonaws.com/dev/import

Done:
1 - authorization-service is added to the repo, has correct basicAuthorizer lambda and correct serverless.yaml file
3 - Import Service serverless.yaml file has authorizer configuration for the importProductsFile lambda. Request to the importProductsFile lambda should work only with correct authorization_token being decoded and checked by basicAuthorizer lambda. Response should be in 403 HTTP status if access is denied for this user (invalid authorization_token) and in 401 HTTP status if Authorization header is not provided.
5 - Client application is updated to send "Authorization: Basic authorization_token" header on import. Client should get authorization_token value from browser